### PR TITLE
loc(): undef strings are passed back as-is

### DIFF
--- a/lib/Locale/Wolowitz.pm
+++ b/lib/Locale/Wolowitz.pm
@@ -180,6 +180,7 @@ passed to the method (C<@args>) are injected to the placeholders in the string
 sub loc {
 	my ($self, $msg, $lang, @args) = @_;
 
+	return unless $msg; # undef strings are passed back as-is
 	return $msg unless $lang;
 
 	my $ret = $self->{locales}->{$msg} && $self->{locales}->{$msg}->{$lang} ? $self->{locales}->{$msg}->{$lang} : $msg;


### PR DESCRIPTION
Passing an empty or undef string to loc() shouldn't result in a crash. For example, when I rand() a list of things to say, and then pass that to loc(), one list item might be undef (say nothing, no text). If my code ends up passing this undef to loc(), Locale::Wolowitz crashes, instead of the common sense "if there's nothing to translate, leave it as-is"

Producing the error "Use of uninitialized value $msg in hash element at /usr/local/share/perl/5.10.1/Locale/Wolowitz.pm line 189." is not such a good idea. At least, we should test the scalar for containing a ref before using it. Or, as in my solution, simply return early.

Apart from that, great module! Using it extensively through Dancer::Plugin::Locale::Wolowitz. So cheers Ido!
