### PR TITLE
Relaxed mode for JSON

### DIFF
--- a/lib/Locale/Wolowitz.pm
+++ b/lib/Locale/Wolowitz.pm
@@ -9,7 +9,7 @@ use utf8;
 use Carp;
 use JSON;
 
-our $VERSION = "1.000001";
+our $VERSION = "1.000002";
 $VERSION = eval $VERSION;
 
 =encoding utf-8
@@ -226,11 +226,12 @@ sub load_path {
 		open(FILE, "$path/$_")
 			|| croak "Can't open localization file $_: $!";
 		local $/;
-		my $json = <FILE>;
+		my $content = <FILE>;
 		close FILE
 			|| carp "Can't close localization file $_: $!";
 
-		my $data = decode_json($json);
+		my $json = JSON->new->utf8->relaxed;
+		my $data = $json->decode($content);
 
 		# is this a one-lang file or a collection?
 		if (m/\.coll\.json$/) {


### PR DESCRIPTION
Sometimes JSON locacalization files are invalid and these files can not be parsed by `decode_json` function. But [JSON module has _relaxed_ mode](http://search.cpan.org/perldoc?JSON#relaxed) which allows to read files with `# perl like comments` and with comma after last data. It is better to enable _relaxed_ as shown in this pull request or to give possibility to enable relaxed mode to users.