### PR TITLE
Don't load dotfiles

### DIFF
--- a/lib/Locale/Wolowitz.pm
+++ b/lib/Locale/Wolowitz.pm
@@ -210,7 +210,7 @@ sub load_path {
 			|| croak "Can't open localization directory: $!";
 	
 		# get all JSON files
-		@files = grep {/\.json$/} readdir PATH;
+		@files = grep {/^[^.].*\.json$/} readdir PATH;
 
 		closedir PATH
 			|| carp "Can't close localization directory: $!";


### PR DESCRIPTION
Dotfiles are supposedly hidden. They are often backup or even binary
files littered by editors or os. This prevents them from loading.