### PR TITLE
deal with more than 10 arguments

### DIFF
--- a/lib/Locale/Wolowitz.pm
+++ b/lib/Locale/Wolowitz.pm
@@ -335,11 +335,7 @@ sub loc {
 
 	my $ret = $self->{locales}->{$msg} && $self->{locales}->{$msg}->{$lang} ? $self->{locales}->{$msg}->{$lang} : $msg;
 
-	if (scalar @args) {
-		for (my $i = 1; $i <= scalar @args; $i++) {
-			$ret =~ s/%$i/$args[$i-1]/g;
-		}
-	}
+    $ret =~ s/%(\d+)/$args[$1-1]/g;
 
 	return $ret;
 }

--- a/t/05-more-than-ten.t
+++ b/t/05-more-than-ten.t
@@ -1,0 +1,22 @@
+#!perl
+
+use strict;
+use warnings;
+use utf8;
+
+use Test::More tests => 2;
+use Locale::Wolowitz;
+
+my $w = Locale::Wolowitz->new;
+
+$w->load_structure({
+    'list' => {
+        fr => '%1 %2 %3 %4 %5 %6 %7 %8 %9 %10',
+    },
+});
+
+is $w->loc('list', 'fr', 'a'..'z')
+    => 'a b c d e f g h i j',
+    'more than 10 arguments';
+
+done_testing();


### PR DESCRIPTION
The regular expression, as it was, wouldn't deal well with 2 digit arguments (e.g., '%10' would be modified as '%1' first).