### PR TITLE
add shorcut for translated arguments

### DIFF
--- a/lib/Locale/Wolowitz.pm
+++ b/lib/Locale/Wolowitz.pm
@@ -325,6 +325,16 @@ a translation exists, otherwise no traslation occurs). Any other parameters
 passed to the method (C<@args>) are injected to the placeholders in the string
 (if present).
 
+If an argument is an array ref, it'll be replaced with
+a recursive call to C<loc> with its elements, with the C<$lang>
+argument automatically added.  In other
+words, the following two statements are equivalent:
+
+    print $w->loc("I'm using %1", 'he', $w->loc('Linux', 'he'));
+    # same result as
+    print $w->loc("I'm using %1", 'he', [ 'Linux' ]);
+
+
 =cut
 
 sub loc {
@@ -332,6 +342,14 @@ sub loc {
 
 	return unless defined $msg; # undef strings are passed back as-is
 	return $msg unless $lang;
+
+    @args = map {
+        ref $_ ne 'ARRAY' ?  $_ : do {
+            my @args = @$_;
+            splice @args, 1, 0, $lang;
+            $self->loc( @args );
+        }
+    } @args;
 
 	my $ret = $self->{locales}->{$msg} && $self->{locales}->{$msg}->{$lang} ? $self->{locales}->{$msg}->{$lang} : $msg;
 

--- a/t/03-direct.t
+++ b/t/03-direct.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use utf8;
 
-use Test::More tests => 4;
+use Test::More tests => 5;
 use Locale::Wolowitz;
 
 my $w = Locale::Wolowitz->new();
@@ -18,7 +18,10 @@ $w->load_structure({
 	'FTW' => {
 		en => 'For The Win',
 		rev_en => 'niW ehT roF'
-	}
+	},
+    doc => {
+        xo => 'bub',
+    },
 });
 
 is($w->loc('OMG', 'en'), 'Oh My God', 'en -> en [1]');
@@ -28,5 +31,10 @@ is($w->loc('FTW', 'rev_en'), 'niW ehT roF', 'en -> rev_en [1]');
 $w->load_path('t/i18n/i18n.coll.json');
 
 is($w->loc("what's up %1?", 'xo', 'zyzyx'), "how's it hangin' zyzyx?", 'en -> xo [1]');
+
+subtest 'translate arguments' => sub {
+    is $w->loc("what's up %1?", 'xo', $w->loc('doc','xo') ), "how's it hangin' bub?", 'classic';
+    is $w->loc("what's up %1?", 'xo', [ 'doc' ] ), "how's it hangin' bub?", 'w/ array ref';
+};
 
 done_testing();


### PR DESCRIPTION
Just to make it easier to translate arguments that
will be in the same language (which I expect will be
most of the cases).